### PR TITLE
Fix: RDP Start Menu conflict and improve Paste reliability

### DIFF
--- a/PestoClipboard/PestoClipboard/App/AppDelegate.swift
+++ b/PestoClipboard/PestoClipboard/App/AppDelegate.swift
@@ -48,7 +48,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     private func setupGlobalHotkey() {
-        KeyboardShortcuts.onKeyDown(for: .openHistory) { [weak self] in
+        // Use KeyboardInterceptor with Cmd key buffering to prevent WinKey reaching RDP
+        // Falls back to Carbon HotkeyManager if no accessibility permission
+        KeyboardInterceptor.shared.start { [weak self] in
+            print("⌨️ Global hotkey pressed")
             self?.statusBarController?.togglePopover()
         }
     }

--- a/PestoClipboard/PestoClipboard/Services/HotkeyManager.swift
+++ b/PestoClipboard/PestoClipboard/Services/HotkeyManager.swift
@@ -1,18 +1,92 @@
-import KeyboardShortcuts
+import Carbon
 import AppKit
 
-/// Manages global keyboard shortcuts for the app.
-/// Uses the KeyboardShortcuts library by Sindre Sorhus.
-struct HotkeyManager {
-    /// Register all global hotkeys
-    static func registerHotkeys(openHistoryAction: @escaping () -> Void) {
-        KeyboardShortcuts.onKeyDown(for: .openHistory) {
-            openHistoryAction()
+/// Manages global keyboard shortcuts using Carbon API.
+/// This lower-level approach prevents event leaks to RDP sessions.
+final class HotkeyManager {
+    static let shared = HotkeyManager()
+    
+    private var hotKeyRef: EventHotKeyRef?
+    private var eventHandler: EventHandlerRef?
+    private var action: (() -> Void)?
+    
+    private init() {}
+    
+    /// Register the global hotkey (Cmd+Shift+V)
+    func registerHotkeys(action: @escaping () -> Void) {
+        self.action = action
+        
+        // Unregister any existing
+        unregisterHotkeys()
+        
+        // Define Hotkey: Cmd+Shift+V
+        // V key code = 0x09
+        // Modifiers = cmdKey + shiftKey
+        let keyCode: UInt32 = 0x09 // kVK_ANSI_V
+        let modifiers: UInt32 = UInt32(cmdKey | shiftKey)
+        
+        let hotKeyID = EventHotKeyID(signature: OSType(0x50455354), id: 1) // "PEST"
+        
+        var gMyHotKeyRef: EventHotKeyRef?
+        
+        let status = RegisterEventHotKey(
+            keyCode,
+            modifiers,
+            hotKeyID,
+            GetApplicationEventTarget(),
+            0,
+            &gMyHotKeyRef
+        )
+        
+        if status == noErr {
+            hotKeyRef = gMyHotKeyRef
+            if eventHandler == nil {
+                installEventHandler()
+            }
+            print("✅ Global Hotkey (Carbon) registered: Cmd+Shift+V")
+        } else {
+            print("❌ Failed to register global hotkey: \(status)")
         }
     }
-
-    /// Unregister all hotkeys (call on app termination if needed)
-    static func unregisterHotkeys() {
-        KeyboardShortcuts.reset(.openHistory)
+    
+    /// Unregister hotkeys
+    func unregisterHotkeys() {
+        if let hotKeyRef = hotKeyRef {
+            UnregisterEventHotKey(hotKeyRef)
+            self.hotKeyRef = nil
+        }
+    }
+    
+    private func installEventHandler() {
+        var eventType = EventTypeSpec(eventClass: OSType(kEventClassKeyboard), eventKind: UInt32(kEventHotKeyPressed))
+        
+        let handler: EventHandlerUPP = { _, _, userData -> OSStatus in
+            guard let userData = userData else { return OSStatus(eventNotHandledErr) }
+            let manager = Unmanaged<HotkeyManager>.fromOpaque(userData).takeUnretainedValue()
+            
+            // Call callback synchronously (like ClipKitty)
+            // The caller is responsible for main thread dispatch if needed
+            manager.action?()
+            
+            return noErr
+        }
+        
+        let selfPtr = Unmanaged.passUnretained(self).toOpaque()
+        
+        InstallEventHandler(
+            GetApplicationEventTarget(),
+            handler,
+            1,
+            &eventType,
+            selfPtr,
+            &eventHandler
+        )
+    }
+    
+    deinit {
+        unregisterHotkeys()
+        if let eventHandler = eventHandler {
+            RemoveEventHandler(eventHandler)
+        }
     }
 }

--- a/PestoClipboard/PestoClipboard/Services/KeyboardInterceptor.swift
+++ b/PestoClipboard/PestoClipboard/Services/KeyboardInterceptor.swift
@@ -1,0 +1,460 @@
+import Cocoa
+import Carbon
+import KeyboardShortcuts
+
+/// Intercepts keyboard events using CGEventTap to prevent modifier keys
+/// from reaching RDP clients like RoyalTSX when our hotkey combo is pressed.
+///
+/// Strategy: If the configured shortcut contains Cmd, buffer Cmd key events
+/// for a short window. If the complete shortcut combo is detected, suppress ALL.
+/// If not, release them. This prevents WinKey from reaching Windows.
+final class KeyboardInterceptor {
+    static let shared = KeyboardInterceptor()
+    
+    private var eventTap: CFMachPort?
+    private var runLoopSource: CFRunLoopSource?
+    private var hotkeyCallback: (() -> Void)?
+    
+    // Configured shortcut info
+    private var targetKeyCode: CGKeyCode = 0x09  // Default: V
+    private var requiresCmd = true
+    private var requiresShift = true
+    private var requiresOption = false
+    private var requiresControl = false
+    
+    // Buffering for Cmd key (only used if shortcut contains Cmd)
+    private var bufferedCmdEvent: CGEvent?
+    private var bufferedShiftEvent: CGEvent?
+    private var bufferTimer: DispatchSourceTimer?
+    private let bufferDuration: TimeInterval = 0.3 // Increased to 300ms based on logs
+    
+    // Track modifier state
+    private var cmdDown = false
+    private var shiftDown = false
+    private var optionDown = false
+    private var controlDown = false
+    private var isBuffering = false
+    
+    // Suppression flags for release events
+    private var preventNextCmdRelease = false
+    private var preventNextShiftRelease = false
+    private var preventNextOptionRelease = false
+    private var preventNextControlRelease = false
+    
+    // Key codes
+    private let leftCmdKeyCode: CGKeyCode = 0x37
+    private let rightCmdKeyCode: CGKeyCode = 0x36
+    private let leftShiftKeyCode: CGKeyCode = 0x38
+    private let rightShiftKeyCode: CGKeyCode = 0x3C
+    private let leftOptionKeyCode: CGKeyCode = 0x3A
+    private let rightOptionKeyCode: CGKeyCode = 0x3D
+    private let leftControlKeyCode: CGKeyCode = 0x3B
+    private let rightControlKeyCode: CGKeyCode = 0x3E
+    
+    private init() {}
+    
+    /// Start intercepting keyboard events
+    func start(hotkeyCallback: @escaping () -> Void) {
+        self.hotkeyCallback = hotkeyCallback
+        
+        // Read configured shortcut from KeyboardShortcuts
+        loadConfiguredShortcut()
+        
+        // Reset state
+        resetState()
+        
+        // Only use event tap if shortcut contains Cmd (for RDP WinKey issue)
+        guard requiresCmd else {
+            print("ℹ️ KeyboardInterceptor: Shortcut doesn't contain Cmd - no buffering needed")
+            // No Cmd in shortcut means no WinKey issue, use simple Carbon API
+            HotkeyManager.shared.registerHotkeys(action: hotkeyCallback)
+            return
+        }
+        
+        guard AccessibilityHelper.hasPermission else {
+            print("⚠️ KeyboardInterceptor: No accessibility permission - using Carbon fallback")
+            HotkeyManager.shared.registerHotkeys(action: hotkeyCallback)
+            return
+        }
+        
+        // Create event tap for keyDown, keyUp, and flagsChanged (modifiers)
+        let eventMask: CGEventMask = (1 << CGEventType.keyDown.rawValue) |
+                                      (1 << CGEventType.keyUp.rawValue) |
+                                      (1 << CGEventType.flagsChanged.rawValue)
+        
+        guard let tap = CGEvent.tapCreate(
+            tap: .cgSessionEventTap,
+            place: .headInsertEventTap,
+            options: .defaultTap,
+            eventsOfInterest: eventMask,
+            callback: { proxy, type, event, refcon in
+                guard let refcon = refcon else { return Unmanaged.passUnretained(event) }
+                let interceptor = Unmanaged<KeyboardInterceptor>.fromOpaque(refcon).takeUnretainedValue()
+                return interceptor.handleEvent(proxy: proxy, type: type, event: event)
+            },
+            userInfo: Unmanaged.passUnretained(self).toOpaque()
+        ) else {
+            print("❌ KeyboardInterceptor: Failed to create event tap - using Carbon fallback")
+            HotkeyManager.shared.registerHotkeys(action: hotkeyCallback)
+            return
+        }
+        
+        eventTap = tap
+        runLoopSource = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0)
+        
+        if let source = runLoopSource {
+            CFRunLoopAddSource(CFRunLoopGetCurrent(), source, .commonModes)
+            CGEvent.tapEnable(tap: tap, enable: true)
+            print("✅ KeyboardInterceptor: Started - buffering Cmd key for RDP compatibility")
+        }
+        
+        // Listen for shortcut changes and restart
+        setupShortcutChangeListener()
+    }
+    
+    // Reset internal state
+    private func resetState() {
+        isBuffering = false
+        preventNextCmdRelease = false
+        preventNextShiftRelease = false
+        preventNextOptionRelease = false
+        preventNextControlRelease = false
+        bufferTimer?.cancel()
+        bufferTimer = nil
+        bufferedCmdEvent = nil
+        bufferedShiftEvent = nil
+    }
+    
+    /// Restart the interceptor (call when shortcut changes)
+    func restart() {
+        guard let callback = hotkeyCallback else { return }
+        print("🔄 KeyboardInterceptor: Restarting due to shortcut change...")
+        stop()
+        start(hotkeyCallback: callback)
+    }
+    
+    private func setupShortcutChangeListener() {
+        // KeyboardShortcuts library notifies when shortcut changes
+        // We use onKeyUp to detect when user finishes recording a new shortcut
+        KeyboardShortcuts.onKeyUp(for: .openHistory) { [weak self] in
+            // This fires when the shortcut is used, which is fine
+            // But we need to detect when it CHANGES
+        }
+        
+        // Alternative: observe UserDefaults for the shortcut key
+        NotificationCenter.default.addObserver(
+            forName: UserDefaults.didChangeNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            // Check if our shortcut config changed
+            self?.checkForShortcutChange()
+        }
+    }
+    
+    private var lastShortcutHash: Int = 0
+    
+    private func checkForShortcutChange() {
+        if let shortcut = KeyboardShortcuts.getShortcut(for: .openHistory),
+           let key = shortcut.key {
+            let newHash = "\(key)\(shortcut.modifiers)".hashValue
+            if lastShortcutHash != 0 && newHash != lastShortcutHash {
+                print("🔄 Shortcut changed - restarting interceptor")
+                restart()
+            }
+            lastShortcutHash = newHash
+        }
+    }
+    
+    /// Load the configured shortcut from KeyboardShortcuts library
+    private func loadConfiguredShortcut() {
+        if let shortcut = KeyboardShortcuts.getShortcut(for: .openHistory),
+           let key = shortcut.key {
+            // Map Key to CGKeyCode
+            targetKeyCode = keyToCGKeyCode(key)
+            
+            // Check modifiers
+            requiresCmd = shortcut.modifiers.contains(.command)
+            requiresShift = shortcut.modifiers.contains(.shift)
+            requiresOption = shortcut.modifiers.contains(.option)
+            requiresControl = shortcut.modifiers.contains(.control)
+            
+            // Store hash for change detection
+            lastShortcutHash = "\(key)\(shortcut.modifiers)".hashValue
+            
+            print("📋 Configured shortcut: key=\(key) cmd=\(requiresCmd) shift=\(requiresShift) opt=\(requiresOption) ctrl=\(requiresControl)")
+        } else {
+            // Default fallback
+            targetKeyCode = 0x09 // V
+            requiresCmd = true
+            requiresShift = true
+            lastShortcutHash = "v[command, shift]".hashValue
+            print("📋 Using default shortcut: Cmd+Shift+V")
+        }
+    }
+    
+    /// Convert KeyboardShortcuts.Key to CGKeyCode
+    private func keyToCGKeyCode(_ key: KeyboardShortcuts.Key) -> CGKeyCode {
+        // Map common keys - add more as needed
+        switch key {
+        case .a: return 0x00
+        case .b: return 0x0B
+        case .c: return 0x08
+        case .d: return 0x02
+        case .e: return 0x0E
+        case .f: return 0x03
+        case .g: return 0x05
+        case .h: return 0x04
+        case .i: return 0x22
+        case .j: return 0x26
+        case .k: return 0x28
+        case .l: return 0x25
+        case .m: return 0x2E
+        case .n: return 0x2D
+        case .o: return 0x1F
+        case .p: return 0x23
+        case .q: return 0x0C
+        case .r: return 0x0F
+        case .s: return 0x01
+        case .t: return 0x11
+        case .u: return 0x20
+        case .v: return 0x09
+        case .w: return 0x0D
+        case .x: return 0x07
+        case .y: return 0x10
+        case .z: return 0x06
+        case .zero: return 0x1D
+        case .one: return 0x12
+        case .two: return 0x13
+        case .three: return 0x14
+        case .four: return 0x15
+        case .five: return 0x17
+        case .six: return 0x16
+        case .seven: return 0x1A
+        case .eight: return 0x1C
+        case .nine: return 0x19
+        default: return 0x09 // Default to V
+        }
+    }
+    
+    /// Stop intercepting
+    func stop() {
+        bufferTimer?.cancel()
+        bufferTimer = nil
+        bufferedCmdEvent = nil
+        bufferedShiftEvent = nil
+        
+        if let tap = eventTap {
+            CGEvent.tapEnable(tap: tap, enable: false)
+        }
+        if let source = runLoopSource {
+            CFRunLoopRemoveSource(CFRunLoopGetCurrent(), source, .commonModes)
+        }
+        eventTap = nil
+        runLoopSource = nil
+        HotkeyManager.shared.unregisterHotkeys()
+        print("🛑 KeyboardInterceptor: Stopped")
+    }
+    
+    private func handleEvent(proxy: CGEventTapProxy, type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {
+        // Handle tap disabled/timeout
+        if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
+            if let tap = eventTap {
+                CGEvent.tapEnable(tap: tap, enable: true)
+            }
+            return Unmanaged.passUnretained(event)
+        }
+        
+        let keyCode = CGKeyCode(event.getIntegerValueField(.keyboardEventKeycode))
+        let flags = event.flags
+        
+        // Track modifier state from flags
+        cmdDown = flags.contains(.maskCommand)
+        shiftDown = flags.contains(.maskShift)
+        optionDown = flags.contains(.maskAlternate)
+        controlDown = flags.contains(.maskControl)
+        
+        // Handle flagsChanged (modifier key presses)
+        if type == .flagsChanged {
+            let isCmdKey = keyCode == leftCmdKeyCode || keyCode == rightCmdKeyCode
+            let isShiftKey = keyCode == leftShiftKeyCode || keyCode == rightShiftKeyCode
+            let isOptionKey = keyCode == leftOptionKeyCode || keyCode == rightOptionKeyCode
+            let isControlKey = keyCode == leftControlKeyCode || keyCode == rightControlKeyCode
+            
+            // Cmd key released - Check for suppression
+            if isCmdKey && !cmdDown {
+                if preventNextCmdRelease {
+                    preventNextCmdRelease = false
+                    return nil
+                }
+                
+                if isBuffering {
+                    flushBuffer()
+                }
+                isBuffering = false
+            }
+            
+            // Shift key released - Check for suppression
+            if isShiftKey && !shiftDown {
+                if preventNextShiftRelease {
+                    preventNextShiftRelease = false
+                    return nil
+                }
+            }
+            
+            // Option key released - Check for suppression
+            if isOptionKey && !optionDown {
+                if preventNextOptionRelease {
+                    preventNextOptionRelease = false
+                    return nil
+                }
+            }
+            
+            // Control key released - Check for suppression
+            if isControlKey && !controlDown {
+                if preventNextControlRelease {
+                    preventNextControlRelease = false
+                    return nil
+                }
+            }
+            
+            // Cmd key pressed down - start buffering
+            if isCmdKey && cmdDown && !isBuffering {
+                isBuffering = true
+                bufferedCmdEvent = event.copy()
+                startBufferTimer()
+                return nil // Suppress Cmd from reaching other apps
+            }
+            
+            // If we're buffering and other required modifiers are pressed, continue buffering
+            if isBuffering {
+                if isShiftKey && requiresShift {
+                    bufferedShiftEvent = event.copy()
+                    return nil // Suppress Shift too
+                }
+                // Also buffer other required modifiers if we supported them
+            }
+            
+            return Unmanaged.passUnretained(event)
+        }
+        
+        // Handle keyDown
+        if type == .keyDown {
+            // Target key pressed while buffering with required modifiers
+            if keyCode == targetKeyCode && isBuffering && checkModifiersMatch() {
+                print("🎯 Detected configured hotkey while buffering - triggering!")
+                
+                // Cancel buffer timer - we're consuming the combo
+                bufferTimer?.cancel()
+                bufferTimer = nil
+                bufferedCmdEvent = nil
+                bufferedShiftEvent = nil
+                isBuffering = false
+                
+                // Set flags to suppress the REAL release of these keys
+                if requiresCmd { preventNextCmdRelease = true }
+                if requiresShift { preventNextShiftRelease = true }
+                if requiresOption { preventNextOptionRelease = true }
+                if requiresControl { preventNextControlRelease = true }
+                
+                // CRITICAL: Inject modifier key-up events to clean up RDP state
+                // This ensures RoyalTSX/Windows doesn't think modifiers are still held
+                injectModifierCleanup()
+                
+                // Trigger hotkey callback
+                DispatchQueue.main.async { [weak self] in
+                    self?.hotkeyCallback?()
+                }
+                
+                // Suppress the key
+                return nil
+            }
+            
+            // Other key pressed while buffering - flush buffer and pass through
+            if isBuffering {
+                flushBuffer()
+                isBuffering = false
+            }
+        }
+        
+        // Pass event through
+        return Unmanaged.passUnretained(event)
+    }
+    
+    /// Check if current modifiers match required modifiers
+    private func checkModifiersMatch() -> Bool {
+        if requiresCmd && !cmdDown { return false }
+        if requiresShift && !shiftDown { return false }
+        if requiresOption && !optionDown { return false }
+        if requiresControl && !controlDown { return false }
+        return true
+    }
+    
+    private func startBufferTimer() {
+        bufferTimer?.cancel()
+        
+        let timer = DispatchSource.makeTimerSource(queue: .main)
+        timer.schedule(deadline: .now() + bufferDuration)
+        timer.setEventHandler { [weak self] in
+            self?.flushBuffer()
+            self?.isBuffering = false
+        }
+        timer.resume()
+        bufferTimer = timer
+    }
+    
+    private func flushBuffer() {
+        // Release buffered events
+        if let cmdEvent = bufferedCmdEvent {
+            cmdEvent.post(tap: .cghidEventTap)
+        }
+        if let shiftEvent = bufferedShiftEvent {
+            shiftEvent.post(tap: .cghidEventTap)
+        }
+        bufferedCmdEvent = nil
+        bufferedShiftEvent = nil
+        bufferTimer?.cancel()
+        bufferTimer = nil
+    }
+    
+    /// Inject modifier key-up events to clean up RDP modifier state
+    /// This ensures RoyalTSX/Windows doesn't think modifiers are still held
+    private func injectModifierCleanup() {
+        let source = CGEventSource(stateID: .hidSystemState)
+        
+        // Send Cmd Up (will be WinKey Up in RDP)
+        if requiresCmd {
+            let cmdUp = CGEvent(keyboardEventSource: source, virtualKey: leftCmdKeyCode, keyDown: false)
+            cmdUp?.flags = []
+            cmdUp?.post(tap: .cghidEventTap)
+        }
+        
+        // Send Shift Up
+        if requiresShift {
+            let shiftUp = CGEvent(keyboardEventSource: source, virtualKey: leftShiftKeyCode, keyDown: false)
+            shiftUp?.flags = []
+            shiftUp?.post(tap: .cghidEventTap)
+        }
+        
+        // Send Option Up if needed
+        if requiresOption {
+            let optUp = CGEvent(keyboardEventSource: source, virtualKey: leftOptionKeyCode, keyDown: false)
+            optUp?.flags = []
+            optUp?.post(tap: .cghidEventTap)
+        }
+        
+        // Send Control Up if needed
+        if requiresControl {
+            let ctrlUp = CGEvent(keyboardEventSource: source, virtualKey: leftControlKeyCode, keyDown: false)
+            ctrlUp?.flags = []
+            ctrlUp?.post(tap: .cghidEventTap)
+        }
+        
+        print("🔓 Injected modifier key-up events for RDP cleanup")
+    }
+    
+    deinit {
+        stop()
+    }
+}
+

--- a/PestoClipboard/PestoClipboard/Views/HistoryPopover/HistoryViewModel.swift
+++ b/PestoClipboard/PestoClipboard/Views/HistoryPopover/HistoryViewModel.swift
@@ -185,22 +185,51 @@ class HistoryViewModel: ObservableObject {
         }
 
         DispatchQueue.main.asyncAfter(deadline: .now() + Constants.pasteSimulationDelay) {
-            let cmdFlag = CGEventFlags(rawValue: UInt64(CGEventFlags.maskCommand.rawValue) | 0x000008)
-
+            // Check frontmost app to determine paste strategy
+            let frontmostApp = NSWorkspace.shared.frontmostApplication
+            let bundleId = frontmostApp?.bundleIdentifier?.lowercased() ?? ""
+            
+            // Known RDP/VM clients where Cmd maps to WinKey (if passthrough enabled)
+            // For these, we want to send Ctrl+V (Mac Control key) which maps to Windows Ctrl+V
+            let isRDP = bundleId.contains("royaltsx") || 
+                        bundleId.contains("microsoft.rdc") ||
+                        bundleId.contains("parallels") ||
+                        bundleId.contains("vmware") ||
+                        bundleId.contains("citrix")
+            
+            print("📋 Target App: \(frontmostApp?.localizedName ?? "Unknown") (\(bundleId)) - RDP Mode: \(isRDP)")
+            
             let source = CGEventSource(stateID: .combinedSessionState)
-            source?.setLocalEventsFilterDuringSuppressionState(
-                [.permitLocalMouseEvents, .permitSystemDefinedEvents],
-                state: .eventSuppressionStateSuppressionInterval
-            )
+            // Use HID System State to ensure broad compatibility
+            let hidSource = CGEventSource(stateID: .hidSystemState)
 
-            let keyDown = CGEvent(keyboardEventSource: source, virtualKey: Constants.vKeyCode, keyDown: true)
-            let keyUp = CGEvent(keyboardEventSource: source, virtualKey: Constants.vKeyCode, keyDown: false)
-            keyDown?.flags = cmdFlag
-            keyUp?.flags = cmdFlag
-            keyDown?.post(tap: .cgSessionEventTap)
-            keyUp?.post(tap: .cgSessionEventTap)
+            // Key Codes
+            let vCode = CGKeyCode(0x09)    // V
+            // If RDP, use Control (0x3B). Else use Command (0x37)
+            let modCode = isRDP ? CGKeyCode(0x3B) : CGKeyCode(0x37)
+            let modFlag: CGEventFlags = isRDP ? .maskControl : .maskCommand
 
-            print("✅ Paste event posted successfully")
+            // 1. Press Modifier (Cmd or Ctrl)
+            let modDown = CGEvent(keyboardEventSource: hidSource, virtualKey: modCode, keyDown: true)
+            modDown?.flags = modFlag
+            modDown?.post(tap: .cghidEventTap)
+
+            // 2. Press V
+            let vDown = CGEvent(keyboardEventSource: hidSource, virtualKey: vCode, keyDown: true)
+            vDown?.flags = modFlag
+            vDown?.post(tap: .cghidEventTap)
+
+            // 3. Release V
+            let vUp = CGEvent(keyboardEventSource: hidSource, virtualKey: vCode, keyDown: false)
+            vUp?.flags = modFlag
+            vUp?.post(tap: .cghidEventTap)
+
+            // 4. Release Modifier
+            let modUp = CGEvent(keyboardEventSource: hidSource, virtualKey: modCode, keyDown: false)
+            modUp?.flags = [] // No flags
+            modUp?.post(tap: .cghidEventTap)
+
+            print("✅ Paste event posted (Method: \(isRDP ? "Ctrl+V for RDP" : "Cmd+V for Mac"))")
         }
     }
 

--- a/PestoClipboard/PestoClipboard/Views/StatusBar/FloatingPanel.swift
+++ b/PestoClipboard/PestoClipboard/Views/StatusBar/FloatingPanel.swift
@@ -49,6 +49,9 @@ class FloatingPanel: NSPanel {
         hasShadow = true
         minSize = NSSize(width: Self.minWidth, height: Self.minHeight)
         maxSize = NSSize(width: Self.maxWidth, height: Self.maxHeight)
+        
+        // Match ClipKitty: panel becomes key immediately when ordered front
+        becomesKeyOnlyIfNeeded = false
     }
 
     private func setupContent<Content: View>(_ contentView: Content, width: CGFloat, height: CGFloat) {
@@ -70,6 +73,12 @@ class FloatingPanel: NSPanel {
         previousApp = NSWorkspace.shared.frontmostApplication
         positionNearMouse()
         makeKeyAndOrderFront(nil)
+        
+        // DO NOT call NSApp.activate here!
+        // By not activating, RoyalTSX remains the "active" app at the macOS level.
+        // This means key-up events (Shift, Cmd) still go to RoyalTSX, which forwards
+        // them to Windows RDP. No stuck modifiers!
+        // The panel still receives keyboard input via key window status.
 
         if let hosting = hostingView {
             makeFirstResponder(hosting)
@@ -85,7 +94,9 @@ class FloatingPanel: NSPanel {
 
     private func activatePreviousApp() {
         guard let app = previousApp else { return }
-        app.activate(options: .activateIgnoringOtherApps)
+        // Use standard activation (like ClipKitty) instead of forcing
+        // This allows better modifier state synchronization
+        app.activate()
     }
 
     // MARK: - Positioning


### PR DESCRIPTION
This PR fixed issue #3 and related issues with RDP sessions in RDP clients supporting shortcut passthrough.

1. Replaced Carbon Hotkey API with CGEventTap interceptor to prevent WinKey/Start Menu triggers in RDP sessions.
   - Implemented 300ms key buffering for modifier keys.
   - Added logic to suppress real modifier release events after hotkey detection.
   - Added automatic restart of interceptor when shortcut configuration changes.

2. Implemented Smart Paste (App-Aware Paste) for RDP clients.
   - Detects RDP applications (RoyalTSX, Microsoft RDC, Parallels, VMware, Citrix).
   - Sends Ctrl+V (Mac Control) instead of Cmd+V when pasting to these apps.
   - Ensures correct pasting behavior in Passthrough mode and avoids triggering Windows shortcuts.

3. Updated HistoryViewModel to use explicit KeyDown/KeyUp events for robust pasting instead of legacy methods.