### PR TITLE
Add per-item expiration to clipboard items

### DIFF
--- a/PestoClipboard/PestoClipboard/Localizable.xcstrings
+++ b/PestoClipboard/PestoClipboard/Localizable.xcstrings
@@ -663,6 +663,12 @@
         }
       }
     },
+    "5 minutes" : {
+
+    },
+    "6 hours" : {
+
+    },
     "7 days" : {
       "localizations" : {
         "ca" : {
@@ -850,6 +856,9 @@
           }
         }
       }
+    },
+    "15 minutes" : {
+
     },
     "30 days" : {
       "localizations" : {
@@ -3298,6 +3307,7 @@
       }
     },
     "Copy to clipboard" : {
+      "extractionState" : "stale",
       "localizations" : {
         "ca" : {
           "stringUnit" : {
@@ -4425,6 +4435,12 @@
           }
         }
       }
+    },
+    "Expire After" : {
+
+    },
+    "Expires %@" : {
+
     },
     "Failed to load clipboard history" : {
       "localizations" : {
@@ -5838,6 +5854,7 @@
       }
     },
     "Installed via App Store" : {
+      "extractionState" : "stale",
       "localizations" : {
         "ca" : {
           "stringUnit" : {
@@ -5932,6 +5949,7 @@
       }
     },
     "Installed via direct download" : {
+      "extractionState" : "stale",
       "localizations" : {
         "ca" : {
           "stringUnit" : {
@@ -6026,6 +6044,7 @@
       }
     },
     "Installed via Homebrew" : {
+      "extractionState" : "stale",
       "localizations" : {
         "ca" : {
           "stringUnit" : {
@@ -9126,6 +9145,9 @@
           }
         }
       }
+    },
+    "Right-click any item and use \"Expire After\" to give it its own countdown. Those items are removed when it runs out, even if starred." : {
+
     },
     "Run Setup Wizard" : {
       "localizations" : {

--- a/PestoClipboard/PestoClipboard/Models/ClipboardItem.swift
+++ b/PestoClipboard/PestoClipboard/Models/ClipboardItem.swift
@@ -14,12 +14,48 @@ public class ClipboardItem: NSManagedObject, Identifiable {
     @NSManaged public var fileURLsData: Data?
     @NSManaged public var isPinned: Bool
     @NSManaged public var totalSizeBytes: Int64
+    @NSManaged public var expiresAt: Date?
+    @NSManaged public var expirationDuration: Double
     @NSManaged public var contents: Set<ClipboardItemContent>?
 
     // MARK: - Computed Properties
 
     var itemType: ClipboardItemType {
         ClipboardItemType(rawValue: contentType) ?? .text
+    }
+
+    // MARK: - Expiration
+
+    /// The lifetime preset currently applied to this item.
+    var expirationOption: ExpirationOption {
+        ExpirationOption(duration: expirationDuration)
+    }
+
+    var hasExpiration: Bool {
+        expiresAt != nil
+    }
+
+    func isExpired(asOf date: Date = Date()) -> Bool {
+        guard let expiresAt else { return false }
+        return expiresAt <= date
+    }
+
+    /// Starts (or restarts) the countdown from `date`. Passing `.never` clears it.
+    func applyExpiration(_ option: ExpirationOption, from date: Date = Date()) {
+        guard let duration = option.duration else {
+            expirationDuration = 0
+            expiresAt = nil
+            return
+        }
+        expirationDuration = duration
+        expiresAt = date.addingTimeInterval(duration)
+    }
+
+    /// Restarts the countdown from `date` if a lifetime is set. Called when an item
+    /// is copied again so re-using a temporary item gives it its full lifetime back.
+    func rearmExpirationIfNeeded(from date: Date = Date()) {
+        guard expirationDuration > 0 else { return }
+        expiresAt = date.addingTimeInterval(expirationDuration)
     }
 
     var fileURLs: [URL]? {
@@ -108,18 +144,48 @@ extension ClipboardItem {
         return NSFetchRequest<ClipboardItem>(entityName: "ClipboardItem")
     }
 
+    /// Matches items whose per-item lifetime has not run out yet. Expired rows are
+    /// filtered out of every list fetch so a stale item can never be shown between
+    /// the moment it expires and the moment the sweep deletes it (after a long
+    /// sleep, for instance).
+    static func unexpiredPredicate(asOf date: Date = Date()) -> NSPredicate {
+        NSPredicate(format: "expiresAt == nil OR expiresAt > %@", date as NSDate)
+    }
+
     static func allItemsFetchRequest() -> NSFetchRequest<ClipboardItem> {
         let request = fetchRequest()
         request.sortDescriptors = [NSSortDescriptor(keyPath: \ClipboardItem.createdAt, ascending: false)]
+        request.predicate = unexpiredPredicate()
         return request
     }
 
     static func searchFetchRequest(query: String) -> NSFetchRequest<ClipboardItem> {
         let request = fetchRequest()
         request.sortDescriptors = [NSSortDescriptor(keyPath: \ClipboardItem.createdAt, ascending: false)]
-        if !query.isEmpty {
-            request.predicate = NSPredicate(format: "textContent CONTAINS[cd] %@", query)
+        if query.isEmpty {
+            request.predicate = unexpiredPredicate()
+        } else {
+            request.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [
+                NSPredicate(format: "textContent CONTAINS[cd] %@", query),
+                unexpiredPredicate()
+            ])
         }
+        return request
+    }
+
+    /// Items whose lifetime has run out and that are ready to be deleted.
+    static func expiredItemsFetchRequest(asOf date: Date = Date()) -> NSFetchRequest<ClipboardItem> {
+        let request = fetchRequest()
+        request.predicate = NSPredicate(format: "expiresAt != nil AND expiresAt <= %@", date as NSDate)
+        return request
+    }
+
+    /// The soonest deadline still in the future, used to schedule the sweep timer.
+    static func nextExpirationFetchRequest(after date: Date = Date()) -> NSFetchRequest<ClipboardItem> {
+        let request = fetchRequest()
+        request.predicate = NSPredicate(format: "expiresAt != nil AND expiresAt > %@", date as NSDate)
+        request.sortDescriptors = [NSSortDescriptor(keyPath: \ClipboardItem.expiresAt, ascending: true)]
+        request.fetchLimit = 1
         return request
     }
 

--- a/PestoClipboard/PestoClipboard/Models/ClipboardItemDecorator.swift
+++ b/PestoClipboard/PestoClipboard/Models/ClipboardItemDecorator.swift
@@ -74,6 +74,13 @@ class ClipboardItemDecorator: ObservableObject, Identifiable, Hashable {
 
     // MARK: - Passthrough Properties
 
+    /// Read live from the item rather than cached at init: decorators are reused
+    /// across refreshes, so a lifetime the user just picked has to show up without
+    /// waiting for the decorator to be rebuilt.
+    var expiresAt: Date? {
+        item.expiresAt
+    }
+
     /// Returns the attributed string for RTF content (loads from Core Data on-demand)
     var attributedString: NSAttributedString? {
         item.attributedString

--- a/PestoClipboard/PestoClipboard/Models/ExpirationOption.swift
+++ b/PestoClipboard/PestoClipboard/Models/ExpirationOption.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+/// Per-item lifetime presets offered in the history context menu.
+///
+/// This is independent of `SettingsManager.AutoDeleteInterval`, which is a global
+/// policy over the whole history. An expiration set here belongs to one item and
+/// is honored even if that item is starred.
+/// `nonisolated` because the target defaults to `MainActor` isolation: this is a
+/// stateless value type and the sweep reads it off the main actor.
+nonisolated enum ExpirationOption: CaseIterable, Identifiable {
+    case never
+    case fiveMinutes
+    case fifteenMinutes
+    case oneHour
+    case sixHours
+    case oneDay
+    case sevenDays
+
+    var id: String { String(describing: self) }
+
+    /// Lifetime in seconds, or nil for `.never`.
+    var duration: TimeInterval? {
+        switch self {
+        case .never: return nil
+        case .fiveMinutes: return 60 * 5
+        case .fifteenMinutes: return 60 * 15
+        case .oneHour: return 3600
+        case .sixHours: return 3600 * 6
+        case .oneDay: return 3600 * 24
+        case .sevenDays: return 3600 * 24 * 7
+        }
+    }
+
+    var localizedName: String {
+        switch self {
+        case .never: return String(localized: "Never")
+        case .fiveMinutes: return String(localized: "5 minutes")
+        case .fifteenMinutes: return String(localized: "15 minutes")
+        case .oneHour: return String(localized: "1 hour")
+        case .sixHours: return String(localized: "6 hours")
+        case .oneDay: return String(localized: "1 day")
+        case .sevenDays: return String(localized: "7 days")
+        }
+    }
+
+    /// Maps a stored `expirationDuration` back to a preset so the menu can show
+    /// which one is active. Durations that don't match a preset (e.g. left over
+    /// from an older build) fall back to `.never`.
+    init(duration: TimeInterval) {
+        self = Self.allCases.first { $0.duration == duration } ?? .never
+    }
+}

--- a/PestoClipboard/PestoClipboard/Models/PersistenceController.swift
+++ b/PestoClipboard/PestoClipboard/Models/PersistenceController.swift
@@ -113,7 +113,9 @@ struct PersistenceController {
         return appFolder.appendingPathComponent("PestoClipboard.sqlite")
     }
 
-    private static func createManagedObjectModel() -> NSManagedObjectModel {
+    /// Internal rather than private so migration tests can build a store from an
+    /// earlier revision of this model and check it still opens.
+    static func createManagedObjectModel() -> NSManagedObjectModel {
         let model = NSManagedObjectModel()
 
         // ClipboardItem entity
@@ -185,6 +187,21 @@ struct PersistenceController {
         totalSizeBytesAttribute.isOptional = false
         totalSizeBytesAttribute.defaultValue = 0
 
+        // Absolute deadline for a per-item expiration; nil means the item never expires
+        // on its own (the global auto-delete setting still applies).
+        let expiresAtAttribute = NSAttributeDescription()
+        expiresAtAttribute.name = "expiresAt"
+        expiresAtAttribute.attributeType = .dateAttributeType
+        expiresAtAttribute.isOptional = true
+
+        // The lifetime the user picked, kept so re-copying an item can re-arm its
+        // countdown and so the UI can show which preset is active. 0 means none.
+        let expirationDurationAttribute = NSAttributeDescription()
+        expirationDurationAttribute.name = "expirationDuration"
+        expirationDurationAttribute.attributeType = .doubleAttributeType
+        expirationDurationAttribute.isOptional = false
+        expirationDurationAttribute.defaultValue = 0.0
+
         // Attributes for ClipboardItemContent
         let contentTypeAttr = NSAttributeDescription()
         contentTypeAttr.name = "type"
@@ -236,6 +253,8 @@ struct PersistenceController {
             fileURLsAttribute,
             isPinnedAttribute,
             totalSizeBytesAttribute,
+            expiresAtAttribute,
+            expirationDurationAttribute,
             contentsRelationship
         ]
 

--- a/PestoClipboard/PestoClipboard/Services/ClipboardHistoryManager.swift
+++ b/PestoClipboard/PestoClipboard/Services/ClipboardHistoryManager.swift
@@ -16,6 +16,7 @@ protocol ClipboardHistoryManaging: AnyObject {
     func addFileItem(urls: [URL])
     func moveToTop(_ item: ClipboardItem)
     func togglePin(_ item: ClipboardItem)
+    func setExpiration(_ option: ExpirationOption, for item: ClipboardItem)
     func updateTextContent(_ item: ClipboardItem, newText: String)
     func deleteItem(_ item: ClipboardItem)
     func deleteItems(at offsets: IndexSet)
@@ -32,6 +33,7 @@ class ClipboardHistoryManager: ObservableObject, ClipboardHistoryManaging {
     private let maxItemsOverride: Int?
     private var cancellables = Set<AnyCancellable>()
     private var autoDeleteTimer: Timer?
+    private var expirationTimer: Timer?
 
     private var maxItems: Int {
         maxItemsOverride ?? SettingsManager.shared.historyLimit
@@ -212,7 +214,10 @@ class ClipboardHistoryManager: ObservableObject, ClipboardHistoryManaging {
 
     func moveToTop(_ item: ClipboardItem) {
         item.createdAt = Date()
+        // Copying a temporary item again gives it its full lifetime back.
+        item.rearmExpirationIfNeeded()
         saveAndRefresh()
+        scheduleNextExpirationSweep()
     }
 
     func togglePin(_ item: ClipboardItem) {
@@ -224,7 +229,9 @@ class ClipboardHistoryManager: ObservableObject, ClipboardHistoryManaging {
         item.textContent = newText
         item.contentHash = computeHash(for: newText)
         item.createdAt = Date()
+        item.rearmExpirationIfNeeded()
         saveAndRefresh()
+        scheduleNextExpirationSweep()
     }
 
     // MARK: - Delete
@@ -301,6 +308,55 @@ class ClipboardHistoryManager: ObservableObject, ClipboardHistoryManaging {
         return digest.map { String(format: "%02x", $0) }.joined()
     }
 
+    // MARK: - Per-Item Expiration
+
+    /// Applies a lifetime to a single item. `.never` clears it.
+    func setExpiration(_ option: ExpirationOption, for item: ClipboardItem) {
+        item.applyExpiration(option)
+        saveAndRefresh()
+        scheduleNextExpirationSweep()
+    }
+
+    /// Deletes items whose per-item lifetime has run out.
+    ///
+    /// Unlike the global auto-delete, this ignores `isPinned`: the countdown was set
+    /// on that specific item on purpose, so it wins over starring.
+    @discardableResult
+    func deleteItemsPastExpiration(asOf date: Date = Date()) -> Int {
+        do {
+            let expired = try viewContext.fetch(ClipboardItem.expiredItemsFetchRequest(asOf: date))
+            guard !expired.isEmpty else { return 0 }
+
+            for item in expired {
+                viewContext.delete(item)
+            }
+            try viewContext.save()
+            fetchItems()
+            return expired.count
+        } catch {
+            print("Failed to delete items past expiration: \(error)")
+            return 0
+        }
+    }
+
+    /// Arms a one-shot timer for the soonest upcoming deadline, so an item disappears
+    /// when it actually expires instead of waiting for the next 5-minute sweep.
+    private func scheduleNextExpirationSweep() {
+        expirationTimer?.invalidate()
+        expirationTimer = nil
+
+        guard let next = try? viewContext.fetch(ClipboardItem.nextExpirationFetchRequest()).first,
+              let expiresAt = next.expiresAt else {
+            return
+        }
+
+        // Fire slightly after the deadline so the item is unambiguously expired.
+        let delay = max(expiresAt.timeIntervalSinceNow + 0.5, 1)
+        expirationTimer = Timer.scheduledTimer(withTimeInterval: delay, repeats: false) { [weak self] _ in
+            self?.runExpirationSweep()
+        }
+    }
+
     // MARK: - Auto-Delete
 
     func startAutoDeleteTimer() {
@@ -310,29 +366,43 @@ class ClipboardHistoryManager: ObservableObject, ClipboardHistoryManaging {
         SettingsManager.shared.$autoDeleteInterval
             .dropFirst()
             .sink { [weak self] _ in
-                self?.performAutoDeleteIfEnabled()
+                self?.runExpirationSweep()
+            }
+            .store(in: &cancellables)
+
+        // Timers don't fire while the machine is asleep, so sweep on wake as well:
+        // an item that expired overnight must be gone when the screen comes back.
+        NSWorkspace.shared.notificationCenter
+            .publisher(for: NSWorkspace.didWakeNotification)
+            .sink { [weak self] _ in
+                self?.runExpirationSweep()
             }
             .store(in: &cancellables)
 
         // Run immediately on start
-        performAutoDeleteIfEnabled()
+        runExpirationSweep()
 
-        // Schedule timer to run every 5 minutes
+        // Backstop sweep every 5 minutes for the global auto-delete setting
         autoDeleteTimer = Timer.scheduledTimer(withTimeInterval: 300, repeats: true) { [weak self] _ in
-            self?.performAutoDeleteIfEnabled()
+            self?.runExpirationSweep()
         }
     }
 
     func stopAutoDeleteTimer() {
         autoDeleteTimer?.invalidate()
         autoDeleteTimer = nil
+        expirationTimer?.invalidate()
+        expirationTimer = nil
     }
 
-    private func performAutoDeleteIfEnabled() {
-        guard let interval = SettingsManager.shared.autoDeleteInterval.timeInterval else {
-            return
+    /// Runs both cleanup policies (global auto-delete + per-item lifetimes) and
+    /// re-arms the timer for the next deadline.
+    private func runExpirationSweep() {
+        if let interval = SettingsManager.shared.autoDeleteInterval.timeInterval {
+            deleteExpiredItems(olderThan: interval)
         }
-        deleteExpiredItems(olderThan: interval)
+        deleteItemsPastExpiration()
+        scheduleNextExpirationSweep()
     }
 
     func deleteExpiredItems(olderThan interval: TimeInterval) {

--- a/PestoClipboard/PestoClipboard/Views/HistoryPopover/HistoryItemRow.swift
+++ b/PestoClipboard/PestoClipboard/Views/HistoryPopover/HistoryItemRow.swift
@@ -30,6 +30,11 @@ struct HistoryItemRow: View {
 
             Spacer(minLength: 4)
 
+            // Countdown for items with their own expiration
+            if let expiresAt = decorator.expiresAt {
+                expirationBadge(expiresAt)
+            }
+
             // Index number for keyboard shortcut (1-9)
             if index <= 9 {
                 Text("\(index)")
@@ -61,6 +66,21 @@ struct HistoryItemRow: View {
         .listRowInsets(EdgeInsets(top: 1, leading: 0, bottom: 1, trailing: 0))
         .listRowSeparator(.hidden)
         .listRowBackground(Color.clear)
+    }
+
+    // MARK: - Expiration
+
+    /// Countdown shown on items that carry their own lifetime. `.relative` keeps the
+    /// text current on its own, so the list doesn't need a per-row ticking timer.
+    private func expirationBadge(_ expiresAt: Date) -> some View {
+        HStack(spacing: 2) {
+            Image(systemName: "clock")
+            Text(expiresAt, style: .relative)
+        }
+        .font(.system(size: 10))
+        .foregroundStyle(.secondary)
+        .fixedSize()
+        .help(Text("Expires \(expiresAt.formatted(date: .abbreviated, time: .shortened))"))
     }
 
     // MARK: - Drag and Drop

--- a/PestoClipboard/PestoClipboard/Views/HistoryPopover/HistoryListView.swift
+++ b/PestoClipboard/PestoClipboard/Views/HistoryPopover/HistoryListView.swift
@@ -86,6 +86,14 @@ struct ItemContextMenu: View {
     @ObservedObject var viewModel: HistoryViewModel
     let onDismiss: () -> Void
 
+    /// Writes through to the history manager so picking a preset applies it immediately.
+    private var expiration: Binding<ExpirationOption> {
+        Binding(
+            get: { item.expirationOption },
+            set: { viewModel.historyManager.setExpiration($0, for: item) }
+        )
+    }
+
     var body: some View {
         Button {
             viewModel.copyToClipboard(item)
@@ -116,6 +124,17 @@ struct ItemContextMenu: View {
                 Label("Edit", systemImage: "pencil")
             }
         }
+
+        Divider()
+
+        Picker(selection: expiration) {
+            ForEach(ExpirationOption.allCases) { option in
+                Text(option.localizedName).tag(option)
+            }
+        } label: {
+            Label("Expire After", systemImage: "clock")
+        }
+        .pickerStyle(.menu)
 
         Divider()
 

--- a/PestoClipboard/PestoClipboard/Views/Preferences/PreferencesView.swift
+++ b/PestoClipboard/PestoClipboard/Views/Preferences/PreferencesView.swift
@@ -385,6 +385,10 @@ struct HistorySettingsView: View {
                         Text("Starred items are never automatically deleted.")
                             .font(.caption)
                             .foregroundStyle(.tertiary)
+
+                        Text("Right-click any item and use \"Expire After\" to give it its own countdown. Those items are removed when it runs out, even if starred.")
+                            .font(.caption)
+                            .foregroundStyle(.tertiary)
                     }
                 }
 

--- a/PestoClipboard/PestoClipboardTests/ClipboardExpirationTests.swift
+++ b/PestoClipboard/PestoClipboardTests/ClipboardExpirationTests.swift
@@ -1,0 +1,219 @@
+import Testing
+import CoreData
+import Foundation
+@testable import Pesto_Clipboard
+
+@MainActor
+struct ClipboardExpirationTests {
+
+    // MARK: - Helpers
+
+    func createManager() -> ClipboardHistoryManager {
+        let persistenceController = PersistenceController(inMemory: true)
+        return ClipboardHistoryManager(persistenceController: persistenceController)
+    }
+
+    /// Backdates an item's deadline so the sweep sees it as expired without waiting.
+    func expire(_ item: ClipboardItem, in manager: ClipboardHistoryManager) {
+        item.expiresAt = Date().addingTimeInterval(-1)
+        try? manager.viewContext.save()
+    }
+
+    // MARK: - ExpirationOption
+
+    @Test func optionDurations() {
+        #expect(ExpirationOption.never.duration == nil)
+        #expect(ExpirationOption.fiveMinutes.duration == 300)
+        #expect(ExpirationOption.fifteenMinutes.duration == 900)
+        #expect(ExpirationOption.oneHour.duration == 3600)
+        #expect(ExpirationOption.sixHours.duration == 21600)
+        #expect(ExpirationOption.oneDay.duration == 86400)
+        #expect(ExpirationOption.sevenDays.duration == 604800)
+    }
+
+    @Test func optionRoundTripsThroughStoredDuration() {
+        for option in ExpirationOption.allCases where option != .never {
+            #expect(ExpirationOption(duration: option.duration!) == option)
+        }
+        // 0 and unknown values fall back to "never"
+        #expect(ExpirationOption(duration: 0) == .never)
+        #expect(ExpirationOption(duration: 42) == .never)
+    }
+
+    // MARK: - Setting an Expiration
+
+    @Test func setExpirationStoresDurationAndDeadline() {
+        let manager = createManager()
+        manager.addTextItem("Temporary secret")
+        let item = manager.items[0]
+
+        manager.setExpiration(.oneHour, for: item)
+
+        #expect(item.expirationDuration == 3600)
+        #expect(item.expirationOption == .oneHour)
+        #expect(item.hasExpiration)
+        // Deadline is roughly an hour out
+        let remaining = item.expiresAt!.timeIntervalSinceNow
+        #expect(remaining > 3590 && remaining <= 3600)
+        #expect(!item.isExpired())
+    }
+
+    @Test func neverClearsExpiration() {
+        let manager = createManager()
+        manager.addTextItem("Temporary secret")
+        let item = manager.items[0]
+
+        manager.setExpiration(.fiveMinutes, for: item)
+        #expect(item.hasExpiration)
+
+        manager.setExpiration(.never, for: item)
+
+        #expect(item.expiresAt == nil)
+        #expect(item.expirationDuration == 0)
+        #expect(item.expirationOption == .never)
+        #expect(!item.hasExpiration)
+    }
+
+    @Test func newItemsHaveNoExpirationByDefault() {
+        let manager = createManager()
+        manager.addTextItem("Plain item")
+
+        let item = manager.items[0]
+        #expect(!item.hasExpiration)
+        #expect(item.expirationOption == .never)
+        #expect(!item.isExpired())
+    }
+
+    // MARK: - Sweeping
+
+    @Test func expiredItemIsHiddenFromFetchBeforeItIsDeleted() {
+        let manager = createManager()
+        manager.addTextItem("Disappearing")
+        let item = manager.items[0]
+        manager.setExpiration(.fiveMinutes, for: item)
+
+        expire(item, in: manager)
+        manager.fetchItems()
+
+        // Still on disk, but never shown to the user
+        #expect(manager.items.isEmpty)
+        #expect(item.isExpired())
+    }
+
+    @Test func expiredItemIsHiddenFromSearch() {
+        let manager = createManager()
+        manager.addTextItem("Disappearing")
+        let item = manager.items[0]
+        manager.setExpiration(.fiveMinutes, for: item)
+
+        expire(item, in: manager)
+        manager.searchItems(query: "Disappearing")
+
+        #expect(manager.items.isEmpty)
+    }
+
+    @Test func sweepDeletesExpiredItems() {
+        let manager = createManager()
+        manager.addTextItem("Disappearing")
+        manager.addTextItem("Staying")
+        let doomed = manager.items.first { $0.textContent == "Disappearing" }!
+        manager.setExpiration(.fiveMinutes, for: doomed)
+
+        expire(doomed, in: manager)
+        let deleted = manager.deleteItemsPastExpiration()
+
+        #expect(deleted == 1)
+        #expect(manager.items.count == 1)
+        #expect(manager.items[0].textContent == "Staying")
+    }
+
+    @Test func sweepLeavesItemsWhoseCountdownIsStillRunning() {
+        let manager = createManager()
+        manager.addTextItem("Still alive")
+        manager.setExpiration(.oneHour, for: manager.items[0])
+
+        let deleted = manager.deleteItemsPastExpiration()
+
+        #expect(deleted == 0)
+        #expect(manager.items.count == 1)
+    }
+
+    @Test func sweepIgnoresItemsWithoutExpiration() {
+        let manager = createManager()
+        manager.addTextItem("No countdown")
+
+        let deleted = manager.deleteItemsPastExpiration()
+
+        #expect(deleted == 0)
+        #expect(manager.items.count == 1)
+    }
+
+    @Test func explicitExpirationBeatsStarring() {
+        // The global auto-delete spares starred items, but a per-item countdown was
+        // set on that item deliberately, so it must still fire.
+        let manager = createManager()
+        manager.addTextItem("Starred but temporary")
+        let item = manager.items[0]
+        manager.togglePin(item)
+        manager.setExpiration(.fiveMinutes, for: item)
+        #expect(item.isPinned)
+
+        expire(item, in: manager)
+
+        #expect(manager.deleteItemsPastExpiration() == 1)
+        #expect(manager.items.isEmpty)
+    }
+
+    @Test func globalAutoDeleteStillSparesStarredItems() {
+        let manager = createManager()
+        manager.addTextItem("Starred, no countdown")
+        manager.togglePin(manager.items[0])
+
+        manager.deleteExpiredItems(olderThan: -1) // everything is "older" than a future cutoff
+
+        #expect(manager.items.count == 1)
+    }
+
+    // MARK: - Re-arming
+
+    @Test func copyingAnItemAgainRestartsItsCountdown() {
+        let manager = createManager()
+        manager.addTextItem("Recurring")
+        let item = manager.items[0]
+        manager.setExpiration(.oneHour, for: item)
+
+        // Simulate a countdown that is nearly done
+        item.expiresAt = Date().addingTimeInterval(5)
+        try? manager.viewContext.save()
+
+        manager.addTextItem("Recurring") // duplicate -> moveToTop
+
+        #expect(manager.items.count == 1)
+        let remaining = item.expiresAt!.timeIntervalSinceNow
+        #expect(remaining > 3590 && remaining <= 3600)
+    }
+
+    @Test func editingTextRestartsCountdown() {
+        let manager = createManager()
+        manager.addTextItem("Before edit")
+        let item = manager.items[0]
+        manager.setExpiration(.oneHour, for: item)
+
+        item.expiresAt = Date().addingTimeInterval(5)
+        try? manager.viewContext.save()
+
+        manager.updateTextContent(item, newText: "After edit")
+
+        let remaining = item.expiresAt!.timeIntervalSinceNow
+        #expect(remaining > 3590 && remaining <= 3600)
+    }
+
+    @Test func itemsWithoutExpirationAreNotArmedByReuse() {
+        let manager = createManager()
+        manager.addTextItem("Recurring")
+        manager.addTextItem("Recurring")
+
+        #expect(manager.items[0].expiresAt == nil)
+        #expect(manager.items[0].expirationDuration == 0)
+    }
+}

--- a/PestoClipboard/PestoClipboardTests/ClipboardItemTests.swift
+++ b/PestoClipboard/PestoClipboardTests/ClipboardItemTests.swift
@@ -197,7 +197,9 @@ struct ClipboardItemTests {
     @Test func searchFetchRequestWithEmptyQuery() {
         let request = ClipboardItem.searchFetchRequest(query: "")
 
-        #expect(request.predicate == nil)
+        // No text filter, but expired items are still held back
+        #expect(request.predicate?.predicateFormat.contains("expiresAt") == true)
+        #expect(request.predicate?.predicateFormat.contains("textContent") == false)
     }
 
     @Test func fetchRequestByHash() {

--- a/PestoClipboard/PestoClipboardTests/ClipboardMonitorTests.swift
+++ b/PestoClipboard/PestoClipboardTests/ClipboardMonitorTests.swift
@@ -20,6 +20,7 @@ final class MockClipboardHistoryManager: ClipboardHistoryManaging {
 
     private(set) var moveToTopCalls: [ClipboardItem] = []
     private(set) var togglePinCalls: [ClipboardItem] = []
+    private(set) var setExpirationCalls: [(option: ExpirationOption, item: ClipboardItem)] = []
     private(set) var updateTextContentCalls: [(item: ClipboardItem, newText: String)] = []
 
     private(set) var deleteItemCalls: [ClipboardItem] = []
@@ -59,6 +60,10 @@ final class MockClipboardHistoryManager: ClipboardHistoryManaging {
 
     func togglePin(_ item: ClipboardItem) {
         togglePinCalls.append(item)
+    }
+
+    func setExpiration(_ option: ExpirationOption, for item: ClipboardItem) {
+        setExpirationCalls.append((option: option, item: item))
     }
 
     func updateTextContent(_ item: ClipboardItem, newText: String) {

--- a/PestoClipboard/PestoClipboardTests/ExpirationMigrationTests.swift
+++ b/PestoClipboard/PestoClipboardTests/ExpirationMigrationTests.swift
@@ -1,0 +1,119 @@
+import Testing
+import CoreData
+import Foundation
+@testable import Pesto_Clipboard
+
+/// Guards the upgrade path for users who already have a clipboard history on disk.
+///
+/// The expiration feature adds two attributes to the `ClipboardItem` entity. If that
+/// change were not lightweight-migratable, `PersistenceController.loadStoreWithRecovery`
+/// would discard the store on first launch and every existing user would lose their
+/// history — so this builds a store with the pre-expiration model and reopens it with
+/// the current one.
+struct ExpirationMigrationTests {
+
+    private static let addedAttributes = ["expiresAt", "expirationDuration"]
+
+    /// The current model minus the expiration attributes, i.e. the shipped v0.3.5 shape.
+    private func modelBeforeExpiration() -> NSManagedObjectModel {
+        let model = PersistenceController.createManagedObjectModel().copy() as! NSManagedObjectModel
+        for entity in model.entities where entity.name == "ClipboardItem" {
+            entity.properties = entity.properties.filter {
+                !Self.addedAttributes.contains($0.name)
+            }
+        }
+        return model
+    }
+
+    private func temporaryStoreURL() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("PestoMigrationTest-\(UUID().uuidString).sqlite")
+    }
+
+    private func removeStore(at url: URL) {
+        for path in [url.path, url.path + "-wal", url.path + "-shm"] {
+            try? FileManager.default.removeItem(atPath: path)
+        }
+    }
+
+    @Test func oldStoreOpensWithTheExpirationModel() throws {
+        let storeURL = temporaryStoreURL()
+        var openCoordinators: [NSPersistentStoreCoordinator] = []
+        defer {
+            // Close the store before deleting the file, or SQLite complains about
+            // its vnode being unlinked while still in use.
+            for coordinator in openCoordinators {
+                for store in coordinator.persistentStores {
+                    try? coordinator.remove(store)
+                }
+            }
+            removeStore(at: storeURL)
+        }
+
+        // 1. Write an item using the pre-expiration model
+        let oldModel = modelBeforeExpiration()
+        #expect(oldModel.entitiesByName["ClipboardItem"]?.attributesByName["expiresAt"] == nil)
+
+        let oldCoordinator = NSPersistentStoreCoordinator(managedObjectModel: oldModel)
+        openCoordinators.append(oldCoordinator)
+        try oldCoordinator.addPersistentStore(
+            ofType: NSSQLiteStoreType, configurationName: nil, at: storeURL, options: nil
+        )
+        let oldContext = NSManagedObjectContext(concurrencyType: .privateQueueConcurrencyType)
+        oldContext.persistentStoreCoordinator = oldCoordinator
+
+        let itemID = UUID()
+        try oldContext.performAndWait {
+            let item = NSEntityDescription.insertNewObject(forEntityName: "ClipboardItem", into: oldContext)
+            // Set through KVC: the typed accessors would touch attributes this model lacks.
+            item.setValue(itemID, forKey: "id")
+            item.setValue(Date(), forKey: "createdAt")
+            item.setValue("text", forKey: "contentType")
+            item.setValue("hash-from-old-version", forKey: "contentHash")
+            item.setValue("History written before the update", forKey: "textContent")
+            item.setValue(true, forKey: "isPinned")
+            try oldContext.save()
+        }
+        for store in oldCoordinator.persistentStores {
+            try oldCoordinator.remove(store)
+        }
+
+        // 2. Reopen the same file with the current model, as the app does on launch
+        let newCoordinator = NSPersistentStoreCoordinator(
+            managedObjectModel: PersistenceController.createManagedObjectModel()
+        )
+        openCoordinators.append(newCoordinator)
+        try newCoordinator.addPersistentStore(
+            ofType: NSSQLiteStoreType,
+            configurationName: nil,
+            at: storeURL,
+            options: [
+                NSMigratePersistentStoresAutomaticallyOption: true,
+                NSInferMappingModelAutomaticallyOption: true
+            ]
+        )
+        let newContext = NSManagedObjectContext(concurrencyType: .privateQueueConcurrencyType)
+        newContext.persistentStoreCoordinator = newCoordinator
+
+        try newContext.performAndWait {
+            let request = ClipboardItem.fetchRequest()
+            request.predicate = NSPredicate(format: "id == %@", itemID as CVarArg)
+            let migrated = try newContext.fetch(request)
+
+            #expect(migrated.count == 1)
+            let item = try #require(migrated.first)
+
+            // Existing data survived
+            #expect(item.textContent == "History written before the update")
+            #expect(item.contentHash == "hash-from-old-version")
+            #expect(item.isPinned)
+
+            // And the new attributes default to "no expiration"
+            #expect(item.expiresAt == nil)
+            #expect(item.expirationDuration == 0)
+            #expect(!item.hasExpiration)
+            #expect(!item.isExpired())
+            #expect(item.expirationOption == .never)
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Fresh, free, and open-source clipboard management.
 - **Search**: Quickly filter your clipboard history
 - **Global Hotkey**: Open history with Cmd+Shift+V (customizable)
 - **Plaintext Paste**: Strip formatting when pasting
+- **Per-Item Expiration**: Give a copied item a lifetime (5 minutes to 7 days) and it deletes itself when the countdown runs out
 - **Launch at Login**: Start automatically when you log in
 
 ## Screenshot


### PR DESCRIPTION
## What

Adds an optional per-item expiration: right-click an item in the history and pick **Expire After** (5 minutes to 7 days), and the item deletes itself when the countdown runs out. A small clock badge on the row shows the remaining time.

This is opt-in and nothing changes for items you don't touch.

## Why not just the existing auto-delete setting?

The `Auto-delete after X` preference is a policy over the whole history. This is for the "I just copied a password / 2FA code / API key and want it gone shortly, but I don't want to shorten my whole history" case, which the global setting can't express. I deliberately did **not** add a second global "default expiration" setting, since it would overlap with the existing one.

## Design notes

- **Model**: `ClipboardItem` gains `expiresAt` (absolute deadline) and `expirationDuration` (the chosen preset). Storing the duration as well is what lets the menu show the active preset with a checkmark, and lets the countdown re-arm when the same item is copied again — reusing a temporary item gives it its full lifetime back instead of letting it die mid-way. Both attributes are additive, so the store migrates lightweight.
- **Deletion** is driven by a one-shot timer armed for the nearest deadline, so a 5-minute lifetime expires on time rather than waiting for the next run of the existing 5-minute sweep. Three fallbacks cover what a timer can't: the periodic sweep, a sweep on `NSWorkspace.didWakeNotification` (timers don't fire while the machine is asleep), and an `expiresAt` filter on the list/search fetch requests, so an expired item is never displayed even if deletion hasn't run yet.
- **Starred items**: an explicit per-item countdown is honored even if the item is starred. The global auto-delete spares starred items, but a lifetime set on one specific item is a deliberate choice about that item, so it wins. The Preferences copy and the row badge make that visible. Happy to flip this if you'd rather starring always win.

## Testing

`ClipboardExpirationTests` covers the presets, the sweep, the fetch filtering, the starred interaction and re-arming.

`ExpirationMigrationTests` builds a store with the pre-expiration model and reopens it with the current one. This felt worth a test because `PersistenceController.loadStoreWithRecovery` discards the store when it can't be opened — so a model change that wasn't lightweight-migratable would silently wipe every existing user's history on first launch.

Full suite: 174 tests passing locally (Xcode 26.6, macOS 26).

## Localization

The six new strings are added to `Localizable.xcstrings` and show up as untranslated in `./scripts/xcstrings.py status`, ready for the usual export/translate/import round. Four of the preset labels (`Never`, `1 hour`, `1 day`, `7 days`) reuse keys that were already translated.
